### PR TITLE
Tame rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,12 @@
+######################################
+############# IMPORTANT ##############
+# When upgrading the RuboCop gem,
+# ensure that new cops do not heavily
+# modify the existing style.
+# Disable any of these new cops.
+######################################
 AllCops:
-  NewCops: disable
+  NewCops: enable
 
 Metrics/BlockLength:
   Enabled: false
@@ -10,25 +17,15 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Enabled: false
 
-Metrics/ClassLength:
-  Enabled: false
-
-# TEMPORARY
-Metrics/BlockNesting:
-  Enabled: false
-
 Style/Documentation:
   Enabled: false
- 
-Lint/Debugger:
-  Exclude:
-    - "run.rb"
 
 Layout/EndOfLine:
   EnforcedStyle: lf
 
+# TODO: Please revert to 100!
 Layout/LineLength:
-  Max: 100
+  Max: 130
 
 # Keep to syntactic linting, instead of complexity.
 Metrics/CyclomaticComplexity:
@@ -40,19 +37,12 @@ Metrics/AbcSize:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-# Pending cops for RuboCop 0.80
-Style/HashEachMethods:
-  Enabled: true
+# TODO: Please correct and remove!
+Metrics/BlockNesting:
+  Enabled: false
 
-Style/HashTransformKeys:
-  Enabled: true
+Metrics/ClassLength:
+  Enabled: false
 
-Style/HashTransformValues:
-  Enabled: true
-
-# Pendng cops for RuboCop 0.81
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
+Lint/SelfAssignment:
+  Enabled: false

--- a/commandrb.gemspec
+++ b/commandrb.gemspec
@@ -3,15 +3,17 @@
 Gem::Specification.new do |s|
   s.name        = 'commandrb'
   s.version     = '0.4.8'
-  s.date        = '2020-10-03'
   s.summary     = 'Commandrb'
   s.description = 'A customisable and easy to use Commands System for Discordrb.'
   s.authors     = ['Erisa A']
   s.email       = 'seriel@erisa.moe'
   s.files       = ['lib/commandrb.rb', 'lib/helper.rb']
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.5'
   s.homepage =
     'https://github.com/Yuuki-Discord/commandrb'
   s.license = 'MIT'
   s.add_runtime_dependency 'discordrb', '~> 3.1', '>= 3.1.0'
+  s.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
 end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -29,7 +29,7 @@ class CommandrbBot
       raise 'Invalid arguments for Helper.avatar_embed!' if url.nil?
 
       colour = 0x22ef1f if color.nil? && colour.nil?
-      username = username.nil? ? 'Unknown User' : username
+      username = 'Unknown User' if username.nil?
       Discordrb::Webhooks::Embed.new(
         colour: colour || color,
         image: Discordrb::Webhooks::EmbedImage.new(url: url),


### PR DESCRIPTION
A newer version of rubocop requests further changes.
Since we're in the mist of rewriting a few components, I chose to adapt Yuuki's existing config and disable `Metrics/BlockNesting`, `Metrics/ClassLength`, and `Lint/SelfAssignment` until we can properly deal with them. Additionally, the maximum line limit was increased to 130.

This style looks alright to me - should we aim to have any other specific style changes throughout rewriting?
<details>
  <summary>RuboCop output suppressed after previous changes</summary>

```
> rubocop -a
Inspecting 6 files
....W.

Offenses:

lib/commandrb.rb:218:101: C: Layout/LineLength: Line is too long. [121/100]
          if !(command[:max_args].nil? || failed) && ((command[:max_args]).positive? && args.length > command[:max_args])
                                                                                                    ^^^^^^^^^^^^^^^^^^^^^
lib/commandrb.rb:229:101: C: Layout/LineLength: Line is too long. [121/100]
          if !(command[:min_args].nil? || failed) && ((command[:min_args]).positive? && args.length < command[:min_args])
                                                                                                    ^^^^^^^^^^^^^^^^^^^^^
lib/commandrb.rb:278:17: C: Metrics/BlockNesting: Avoid more than 3 levels of block nesting.
                if send_error.nil? ...
                ^^^^^^^^^^^^^^^^^^
lib/commandrb.rb:294:11: W: Lint/SelfAssignment: Self-assignment detected.
          command = command
          ^^^^^^^^^^^^^^^^^
lib/commandrb.rb:295:11: W: Lint/SelfAssignment: Self-assignment detected.
          event = event
          ^^^^^^^^^^^^^
lib/commandrb.rb:296:11: W: Lint/SelfAssignment: Self-assignment detected.
          args = args
          ^^^^^^^^^^^
lib/commandrb.rb:297:11: W: Lint/SelfAssignment: Self-assignment detected.
          rawargs = rawargs
          ^^^^^^^^^^^^^^^^^

6 files inspected, 7 offenses detected
```
</summary>